### PR TITLE
Fix CSV header format

### DIFF
--- a/bin/ncmb-csv-export
+++ b/bin/ncmb-csv-export
@@ -61,7 +61,7 @@ var data2CSV= function(data) {
       }
     }
   }
-  csv = [header.join("\t")];
+  csv = [header.join(",")];
   for(var i in data) {
     var row = data[i];
     var line = [];


### PR DESCRIPTION
Using "," in CSV header is more useful when `ncmb csv import` the same file.